### PR TITLE
Make the PHP launcher write an ack on init

### DIFF
--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -117,4 +117,7 @@ ADD compile.php /bin/compile.php
 ADD runner.php /bin/runner.php
 ENV OW_COMPILER=/bin/compile.php
 
+# the launcher must wait for an ack
+ENV OW_WAIT_FOR_ACK=1
+
 ENTRYPOINT [ "/bin/proxy" ]

--- a/core/php8.0Action/runner.php
+++ b/core/php8.0Action/runner.php
@@ -39,6 +39,8 @@ $__functionName = $argv[1] ?? 'main';
 
 $sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n";
 
+fwrite($fd3, "{\"ok\":true}\n");
+
 // read stdin
 while ($f = fgets(STDIN)) {
     // call the function


### PR DESCRIPTION
This evens out the PHP runtime to our other runtimes so that we can safely rely on the init ack mechanism being exercised. This is better than an arbitrary timeout anyway.