### PR TITLE
SERVERLESS-1465 Update PHP and Golang versions to more recent ones

### DIFF
--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -16,16 +16,17 @@
 #
 
 # build go proxy from source
-FROM golang:1.15 AS builder_source
+ARG GO_PROXY_BASE_IMAGE=golang:1.18
+FROM $GO_PROXY_BASE_IMAGE AS builder_source
 ARG GO_PROXY_GITHUB_USER=nimbella-corp
 ARG GO_PROXY_GITHUB_BRANCH=dev
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
-   https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
-   cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
-   mv proxy /bin/proxy
+  https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
+  cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
+  mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.15 AS builder_release
+FROM $GO_PROXY_BASE_IMAGE AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
@@ -33,7 +34,7 @@ RUN curl -sL \
   && cd openwhisk-runtime-go-*/main\
   && GO111MODULE=on go build -o /bin/proxy
 
-FROM php:8.0.2-cli-buster
+FROM php:8.0-cli-buster
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=source


### PR DESCRIPTION
1. The Golang version we're building the proxy with is ancient. 1.18 is the most recent and known to work.
2. The PHP patch versions is unnecessarily pinned. We can update to 8.0.19 by unpinning it.