### PR TITLE
Include functions deployer in runtime image

### DIFF
--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -103,10 +103,17 @@ RUN mkdir -p /phpAction/composer
 COPY composer.json /phpAction/composer
 RUN cd /phpAction/composer && /usr/bin/composer install --no-plugins --no-scripts --prefer-dist --no-dev -o && rm composer.lock
 
-# install nim
-ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
+# install nim (to be retired once we are fully switched to using functions-deployer)
+ARG NIM_INSTALL_SCRIPT
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl ${NIM_INSTALL_SCRIPT} | bash
+
+# install the functions-deployer (co-exist with nim temporarily)
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
 
 # install proxy binary along with compile and launcher scripts
 RUN mkdir -p /phpAction/action


### PR DESCRIPTION
This change adds logic to the docker build to incorporate the functions deployer ('dosls' command) in the runtime image.   Remote builds will soon switch to using it, rather than 'nim', after which the 'nim' install will be retired.