### PR TITLE
Remove the nim install

### DIFF
--- a/core/php8.0Action/Dockerfile
+++ b/core/php8.0Action/Dockerfile
@@ -103,12 +103,7 @@ RUN mkdir -p /phpAction/composer
 COPY composer.json /phpAction/composer
 RUN cd /phpAction/composer && /usr/bin/composer install --no-plugins --no-scripts --prefer-dist --no-dev -o && rm composer.lock
 
-# install nim (to be retired once we are fully switched to using functions-deployer)
-ARG NIM_INSTALL_SCRIPT
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl ${NIM_INSTALL_SCRIPT} | bash
-
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \


### PR DESCRIPTION
We previously added an install for the DigitalOcean functions deployer. The builder actions have been revised to invoke it instead of `nim`. This PR completes the switch-over by removing `nim`.