### PR TITLE
SERVERLESS-2327 Map environment into a context parameter

### DIFF
--- a/core/php8.0Action/runner.php
+++ b/core/php8.0Action/runner.php
@@ -25,6 +25,9 @@ class Context {
     public $activationId;
     public $requestId;
     public $deadline;
+    public $apiHost;
+    public $apiKey;
+    public $namespace;
 
     function getRemainingTimeInMillis() {
         $epochNowInMs = floor(microtime(true) * 1000);
@@ -78,6 +81,9 @@ while ($f = fgets(STDIN)) {
     $context->activationId = getenv('__OW_ACTIVATION_ID');
     $context->requestId = getenv('__OW_TRANSACTION_ID');
     $context->deadline = intval(getenv('__OW_DEADLINE'));
+    $context->apiHost = getenv('__OW_API_HOST');
+    $context->apiKey = getenv('__OW_AUTH_KEY') ?: "";
+    $context->namespace = getenv('__OW_NAMESPACE');
 
     $values = $data['value'] ?? [];
     try {

--- a/core/php8.0Action/runner.php
+++ b/core/php8.0Action/runner.php
@@ -82,7 +82,7 @@ while ($f = fgets(STDIN)) {
     $context->requestId = getenv('__OW_TRANSACTION_ID');
     $context->deadline = intval(getenv('__OW_DEADLINE'));
     $context->apiHost = getenv('__OW_API_HOST');
-    $context->apiKey = getenv('__OW_AUTH_KEY') ?: "";
+    $context->apiKey = getenv('__OW_API_KEY') ?: "";
     $context->namespace = getenv('__OW_NAMESPACE');
 
     $values = $data['value'] ?? [];

--- a/core/php8.0Action/runner.php
+++ b/core/php8.0Action/runner.php
@@ -23,6 +23,7 @@ class Context {
     public $functionName;
     public $functionVersion;
     public $activationId;
+    public $requestId;
     public $deadline;
 
     function getRemainingTimeInMillis() {
@@ -75,6 +76,7 @@ while ($f = fgets(STDIN)) {
     $context->functionName = getenv('__OW_ACTION_NAME');
     $context->functionVersion = getenv('__OW_ACTION_VERSION');
     $context->activationId = getenv('__OW_ACTIVATION_ID');
+    $context->requestId = getenv('__OW_TRANSACTION_ID');
     $context->deadline = intval(getenv('__OW_DEADLINE'));
 
     $values = $data['value'] ?? [];

--- a/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
@@ -470,7 +470,7 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
   }
 
   it should s"support a function with a context parameter" in {
-    val (out, err) = withPhp7Container { c =>
+    val (out, err) = withActionContainer(Map("__OW_API_HOST" -> "testhost")) { c =>
       val code =
         """
           | <?php
@@ -480,7 +480,10 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
           |         "activation_id" => $context->activationId,
           |         "request_id" => $context->requestId,
           |         "function_name" => $context->functionName,
-          |         "function_version" => $context->functionVersion
+          |         "function_version" => $context->functionVersion,
+          |         "api_host" => $context->apiHost,
+          |         "api_key" => $context->apiKey,
+          |         "namespace" => $context->namespace
           |      ];
           | }
         """.stripMargin
@@ -495,7 +498,9 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
           "activation_id" -> "testaid".toJson,
           "transaction_id" -> "testtid".toJson,
           "action_name" -> "testfunction".toJson,
-          "action_version" -> "0.0.1".toJson
+          "action_version" -> "0.0.1".toJson,
+          "namespace" -> "testnamespace".toJson,
+          "auth_key" -> "testkey".toJson
         ))
       ))
       runCode should be(200)
@@ -507,7 +512,10 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
         "activation_id" -> "testaid".toJson,
         "request_id" -> "testtid".toJson,
         "function_name" -> "testfunction".toJson,
-        "function_version" -> "0.0.1".toJson
+        "function_version" -> "0.0.1".toJson,
+        "api_host" -> "testhost".toJson,
+        "api_key" -> "testkey".toJson,
+        "namespace" -> "testnamespace".toJson
       ))
     }
   }

--- a/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
@@ -500,7 +500,7 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
           "action_name" -> "testfunction".toJson,
           "action_version" -> "0.0.1".toJson,
           "namespace" -> "testnamespace".toJson,
-          "auth_key" -> "testkey".toJson
+          "api_key" -> "testkey".toJson
         ))
       ))
       runCode should be(200)

--- a/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
@@ -478,6 +478,7 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
           |     return [
           |         "remaining_time" => $context->getRemainingTimeInMillis(),
           |         "activation_id" => $context->activationId,
+          |         "request_id" => $context->requestId,
           |         "function_name" => $context->functionName,
           |         "function_version" => $context->functionVersion
           |      ];
@@ -491,7 +492,8 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
         JsObject(),
         Some(JsObject(
           "deadline" -> Instant.now.plusSeconds(10).toEpochMilli.toString.toJson,
-          "activation_id" -> "testid".toJson,
+          "activation_id" -> "testaid".toJson,
+          "transaction_id" -> "testtid".toJson,
           "action_name" -> "testfunction".toJson,
           "action_version" -> "0.0.1".toJson
         ))
@@ -502,7 +504,8 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
       remainingTime should be > 9500 // We give the test 500ms of slack to invoke the function to avoid flakes.
       out shouldBe Some(JsObject(
         "remaining_time" -> remainingTime.toJson,
-        "activation_id" -> "testid".toJson,
+        "activation_id" -> "testaid".toJson,
+        "request_id" -> "testtid".toJson,
         "function_name" -> "testfunction".toJson,
         "function_version" -> "0.0.1".toJson
       ))


### PR DESCRIPTION
This translates our current environment variable based approach into passing a second "context" parameter to the function. This resembles the context objects we're introducing to all other languages.

Given the loosely typed nature of PHP, both using `Context` and `object` as the type for the parameters works. Since the user's IDE won't have the Context type in scope, it might bark at that potentially.