### PR TITLE
SERVERLESS-2402 Add a PHP 8.2 runtime

### DIFF
--- a/core/php8.2Action/Dockerfile
+++ b/core/php8.2Action/Dockerfile
@@ -16,28 +16,15 @@
 #
 
 # build go proxy from source
-ARG GO_PROXY_BASE_IMAGE=golang:1.18
-FROM $GO_PROXY_BASE_IMAGE AS builder_source
-ARG GO_PROXY_GITHUB_USER=nimbella-corp
+ARG GO_PROXY_BASE_IMAGE=golang:1.20
+FROM $GO_PROXY_BASE_IMAGE AS builder
+ARG GO_PROXY_GITHUB_USER=nimbella
 ARG GO_PROXY_GITHUB_BRANCH=dev
-RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
-  https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
-  cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
-  mv proxy /bin/proxy
-
-# or build it from a release
-FROM $GO_PROXY_BASE_IMAGE AS builder_release
-ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
-RUN curl -sL \
-  https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
-  | tar xzf -\
-  && cd openwhisk-runtime-go-*/main\
-  && GO111MODULE=on go build -o /bin/proxy
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src \
+  && cd /src \
+  && env GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy main/proxy.go
 
 FROM php:8.2-cli-bullseye
-
-# select the builder to use
-ARG GO_PROXY_BUILD_FROM=source
 
 COPY php.ini /usr/local/etc/php
 
@@ -80,9 +67,6 @@ RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
 # install proxy binary along with compile and launcher scripts
 RUN mkdir -p /phpAction/action
 WORKDIR /phpAction
-COPY --from=builder_source /bin/proxy /bin/proxy_source
-COPY --from=builder_release /bin/proxy /bin/proxy_release
-RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
 COPY compile.php /bin/compile.php
 COPY runner.php /bin/runner.php
 ENV OW_COMPILER=/bin/compile.php
@@ -90,4 +74,5 @@ ENV OW_COMPILER=/bin/compile.php
 # the launcher must wait for an ack
 ENV OW_WAIT_FOR_ACK=1
 
+COPY --from=builder /bin/proxy /bin/proxy
 ENTRYPOINT [ "/bin/proxy" ]

--- a/core/php8.2Action/Dockerfile
+++ b/core/php8.2Action/Dockerfile
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# build go proxy from source
+ARG GO_PROXY_BASE_IMAGE=golang:1.18
+FROM $GO_PROXY_BASE_IMAGE AS builder_source
+ARG GO_PROXY_GITHUB_USER=nimbella-corp
+ARG GO_PROXY_GITHUB_BRANCH=dev
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
+  https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
+  cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
+  mv proxy /bin/proxy
+
+# or build it from a release
+FROM $GO_PROXY_BASE_IMAGE AS builder_release
+ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
+RUN curl -sL \
+  https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
+  | tar xzf -\
+  && cd openwhisk-runtime-go-*/main\
+  && GO111MODULE=on go build -o /bin/proxy
+
+FROM php:8.2-cli-bullseye
+
+# select the builder to use
+ARG GO_PROXY_BUILD_FROM=source
+
+COPY php.ini /usr/local/etc/php
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # install Python to allow the builder to run correctly.
+    python \
+  && rm -rf /var/lib/apt/lists/*
+
+# install PHP extensions
+RUN curl -sSLf -o /usr/local/bin/install-php-extensions \
+    https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
+  && chmod +x /usr/local/bin/install-php-extensions \
+  && install-php-extensions \
+    @composer \
+    bcmath \
+    gd \
+    intl \
+    mongodb \
+    mysqli \
+    opcache \
+    pdo_mysql \
+    pdo_pgsql \
+    soap \
+    zip
+
+# install default Composer dependencies
+COPY composer.json /phpAction/composer/composer.json
+RUN cd /phpAction/composer \
+  && composer install --no-plugins --no-scripts --prefer-dist --no-dev -o \
+  && rm composer.lock
+
+# install the functions-deployer
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
+
+# install proxy binary along with compile and launcher scripts
+RUN mkdir -p /phpAction/action
+WORKDIR /phpAction
+COPY --from=builder_source /bin/proxy /bin/proxy_source
+COPY --from=builder_release /bin/proxy /bin/proxy_release
+RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
+COPY compile.php /bin/compile.php
+COPY runner.php /bin/runner.php
+ENV OW_COMPILER=/bin/compile.php
+
+# the launcher must wait for an ack
+ENV OW_WAIT_FOR_ACK=1
+
+ENTRYPOINT [ "/bin/proxy" ]

--- a/core/php8.2Action/build.gradle
+++ b/core/php8.2Action/build.gradle
@@ -15,25 +15,5 @@
  * limitations under the License.
  */
 
-include 'tests'
-
-include 'core:php7.3Action'
-include 'core:php7.4Action'
-include 'core:php8.0Action'
-include 'core:php8.2Action'
-
-rootProject.name = 'runtime-php'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+ext.dockerImageName = 'action-php-v8.2'
+apply from: '../../gradle/docker.gradle'

--- a/core/php8.2Action/compile.php
+++ b/core/php8.2Action/compile.php
@@ -1,0 +1,82 @@
+#!/usr/bin/env php
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * compile
+ *
+ * This file is launched by the action proxy.
+ * It copies runner.php to right source directory and creates a bash exec script
+ * that the action proxy will call to start everything off
+ */
+
+main($argc, $argv);
+exit;
+
+function main($argc, $argv)
+{
+    if ($argc < 4) {
+        print("usage: <main-function-name> <source-dir> <bin-dir>");
+        exit(1);
+    }
+    $main = $argv[1];
+    $src = realpath($argv[2]);
+    $bin = realpath($argv[3]);
+
+    $shim = $bin.'/exec';
+
+    sources($src);
+    build($shim, $src, $main);
+}
+
+/**
+ * Sort out the source code
+ *
+ * 1. Copy src/exec to src/index.php if necessary
+ * 2. Ensure vendor directory exists
+ */
+function sources(string $src)
+{
+    // If the file uploaded by the user is a plain PHP file, then
+    // the filename will be called exec by the action proxy.
+    // Rename it to index.php
+    if (file_exists($src . '/exec')) {
+        rename($src . '/exec', $src . '/index.php');
+    }
+
+    // put vendor in the right place if it doesn't exist
+    if (!is_dir($src . '/vendor')) {
+        exec('cp -a /phpAction/composer/vendor ' . escapeshellarg($src . '/vendor'));
+    }
+}
+
+/**
+ * Create bin/exec shim
+ */
+function build(string $shim, string $src, string $main) : void
+{
+    $contents = <<<EOT
+#!/bin/bash
+cd $src
+exec php -f /bin/runner.php -- "$main"
+
+EOT;
+
+    file_put_contents($shim, $contents);
+    chmod($shim, 0755);
+}

--- a/core/php8.2Action/composer.json
+++ b/core/php8.2Action/composer.json
@@ -1,0 +1,12 @@
+{
+    "config": {
+        "platform": {
+            "php": "8.2"
+        }
+    },
+    "require": {
+        "guzzlehttp/guzzle": "7.5.1",
+        "ramsey/uuid": "4.7.4",
+        "nimbella/nimbella": "^1.1"
+    }
+}

--- a/core/php8.2Action/php.ini
+++ b/core/php8.2Action/php.ini
@@ -1,0 +1,37 @@
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.
+; The ASF licenses this file to You under the Apache License, Version 2.0
+; (the "License"); you may not use this file except in compliance with
+; the License.  You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[PHP]
+short_open_tag = Off
+output_buffering = Off
+expose_php = Off
+max_execution_time = 0
+memory_limit = -1
+error_reporting = E_ALL
+display_errors = Off
+log_errors = On
+log_errors_max_len = 0
+html_errors = Off
+variables_order = "EGPCS"
+request_order = "GP"
+post_max_size = 0
+enable_dl = Off
+zend.assertions = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.max_accelerated_files=7963
+opcache.validate_timestamps=0

--- a/core/php8.2Action/runner.php
+++ b/core/php8.2Action/runner.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * PHP Action runner
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ // Context is a wrapper type for the optional second parameter.
+class Context {
+    public $functionName;
+    public $functionVersion;
+    public $activationId;
+    public $requestId;
+    public $deadline;
+    public $apiHost;
+    public $apiKey;
+    public $namespace;
+
+    function getRemainingTimeInMillis() {
+        $epochNowInMs = floor(microtime(true) * 1000);
+        $deltaMs = $this->deadline - $epochNowInMs;
+        return $deltaMs > 0 ? $deltaMs : 0;
+    }
+}
+
+// open fd/3 as that's where we send the result
+$fd3 = fopen('php://fd/3', 'wb');
+
+// Register a shutdown function so that we can fail gracefully when a fatal error occurs
+register_shutdown_function(static function () use ($fd3) {
+    $error = error_get_last();
+    if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR], true)) {
+        file_put_contents('php://stderr', "An error occurred running the function.\n");
+        fwrite($fd3, "An error occurred running the function.\n");
+    }
+    fclose($fd3);
+});
+
+require 'vendor/autoload.php';
+require 'index.php';
+
+// retrieve main function
+$__functionName = $argv[1] ?? 'main';
+
+$sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n";
+
+// Ack the initialization.
+fwrite($fd3, "{\"ok\":true}\n");
+
+// read stdin
+while ($f = fgets(STDIN)) {
+    // call the function
+    $data = json_decode($f ?? '', true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+
+    // convert all parameters other than value to environment variables
+    foreach ($data as $key => $value) {
+        if ($key !== 'value') {
+            $envKeyName = '__OW_' . strtoupper($key);
+            $_ENV[$envKeyName] = $value;
+            putenv($envKeyName . '=' . $value);
+        }
+    }
+
+    // Construct a context.
+    $context = new Context;
+    $context->functionName = getenv('__OW_ACTION_NAME');
+    $context->functionVersion = getenv('__OW_ACTION_VERSION');
+    $context->activationId = getenv('__OW_ACTIVATION_ID');
+    $context->requestId = getenv('__OW_TRANSACTION_ID');
+    $context->deadline = intval(getenv('__OW_DEADLINE'));
+    $context->apiHost = getenv('__OW_API_HOST');
+    $context->apiKey = getenv('__OW_API_KEY') ?: "";
+    $context->namespace = getenv('__OW_NAMESPACE');
+
+    $values = $data['value'] ?? [];
+    try {
+        // It's safe to always pass both values in PHP as the context parameter would just be
+        // ignored if the user's not accessing it.
+        $result = $__functionName($values, $context);
+
+        // convert result to an array if we can
+        if (is_object($result)) {
+            if (method_exists($result, 'getArrayCopy')) {
+                $result = $result->getArrayCopy();
+            } elseif ($result instanceof stdClass) {
+                $result = (array)$result;
+            }
+        } elseif ($result === null) {
+            $result = [];
+        }
+
+        // process the result
+        if (!is_array($result)) {
+            file_put_contents('php://stderr', 'Result must be an array but has type "'
+                . gettype($result) . '": ' . $result);
+            file_put_contents('php://stdout', 'The function did not return a dictionary.');
+            $result = (string)$result;
+        } else {
+            $result = json_encode((object)$result);
+        }
+    } catch (Throwable $e) {
+        file_put_contents('php://stderr', (string)$e);
+        $result = 'An error occurred running the function.';
+    }
+
+    // ensure that the sentinels will be on their own lines
+    file_put_contents('php://stderr', "\n" . $sentinel);
+    file_put_contents('php://stdout', "\n" . $sentinel);
+
+    // cast result to an object for json_encode to ensure that an empty array becomes "{}" & send to fd/3
+    fwrite($fd3, $result . "\n");
+}

--- a/tests/src/test/scala/runtime/actionContainers/Php82ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php82ActionContainerTests.scala
@@ -15,25 +15,13 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'core:php7.3Action'
-include 'core:php7.4Action'
-include 'core:php8.0Action'
-include 'core:php8.2Action'
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-rootProject.name = 'runtime-php'
+@RunWith(classOf[JUnitRunner])
+class Php82ActionContainerTests extends Php7ActionContainerTests {
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+  override lazy val phpContainerImageName = "action-php-v8.2"
+}


### PR DESCRIPTION
This adds PHP 8.2 as PHP 8.0 is out of support. It's mostly a 1:1 copy with a few notable changes:
1. To boost maintainability, this uses docker-php-extension-installer to install dependencies and PHP extensions.
2. Updated composer dependencies.
3. Acks on inits vs. using an arbitrary timeout.