### PR TITLE
SERVERLESS-2980 Surface any errors as JSON objects correctly

### DIFF
--- a/core/php8.2Action/runner.php
+++ b/core/php8.2Action/runner.php
@@ -44,7 +44,7 @@ register_shutdown_function(static function () use ($fd3) {
     $error = error_get_last();
     if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR], true)) {
         file_put_contents('php://stderr', "An error occurred running the function.\n");
-        fwrite($fd3, "An error occurred running the function.\n");
+        fwrite($fd3, '{"error": "An error occurred running the function."}' . "\n");
     }
     fclose($fd3);
 });
@@ -58,7 +58,7 @@ $__functionName = $argv[1] ?? 'main';
 $sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n";
 
 // Ack the initialization.
-fwrite($fd3, "{\"ok\":true}\n");
+fwrite($fd3, '{"ok":true}' . "\n");
 
 // read stdin
 while ($f = fgets(STDIN)) {
@@ -107,22 +107,21 @@ while ($f = fgets(STDIN)) {
 
         // process the result
         if (!is_array($result)) {
-            file_put_contents('php://stderr', 'Result must be an array but has type "'
-                . gettype($result) . '": ' . $result);
+            file_put_contents('php://stderr', 'Result must be an array but has type "' . gettype($result) . '": ' . $result);
             file_put_contents('php://stdout', 'The function did not return a dictionary.');
             $result = (string)$result;
         } else {
+            // cast result to an object for json_encode to ensure that an empty array becomes "{}" & send to fd/3
             $result = json_encode((object)$result);
         }
     } catch (Throwable $e) {
         file_put_contents('php://stderr', (string)$e);
-        $result = 'An error occurred running the function.';
+        $result = '{"error": "An error occurred running the function."}';
     }
 
     // ensure that the sentinels will be on their own lines
     file_put_contents('php://stderr', "\n" . $sentinel);
     file_put_contents('php://stdout', "\n" . $sentinel);
 
-    // cast result to an object for json_encode to ensure that an empty array becomes "{}" & send to fd/3
     fwrite($fd3, $result . "\n");
 }

--- a/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
@@ -148,8 +148,7 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
       runCode should not be (200)
 
       runRes shouldBe defined
-      runRes.get.fields.get("error") shouldBe defined
-    // runRes.get.fields("error").toString.toLowerCase should include("nooooo")
+      runRes.get.fields.get("error") shouldBe Some(JsString("An error occurred running the function."))
     }
 
     // Somewhere, the logs should be the error text
@@ -254,7 +253,7 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
       runCode should be(502)
 
       runRes shouldBe defined
-      runRes.get.fields.get("error") shouldBe defined
+      runRes.get.fields.get("error") shouldBe Some(JsString("An error occurred running the function."))
     }
 
     // Somewhere, the logs should be the error text


### PR DESCRIPTION
Currently, whenever an uncaught error happens, the runtime returns plain strings to the proxy. It expects JSON objects though, so it can't really deal with the response.

This makes it so that error objects are returned on all error paths.